### PR TITLE
Fixed 'Could not load illustration!' in release mode on Android

### DIFF
--- a/lib/ms_undraw.dart
+++ b/lib/ms_undraw.dart
@@ -99,8 +99,7 @@ class UnDraw extends StatelessWidget {
     String image =
         await _getSvgString(illustrationMap[illustration]!, this.useMemCache);
 
-    String valueString = color.toString().split('(0x')[1].split(')')[0];
-    valueString = valueString.substring(2, valueString.length);
+    String valueString = color.value.toRadixString(16);
     image = image.replaceAll("#6c63ff", "#" + valueString);
     return SvgPicture.string(
       image,


### PR DESCRIPTION
Color.toString() can sometimes return "Instance of Color" instead of the usual "Color(0xXXXXXX)" in release mode, at least on Android. Using Color.value.toRadixString(16) is more reliable and simpler.